### PR TITLE
fix: fetch all problems via paginated API requests

### DIFF
--- a/fetch_problems_all.py
+++ b/fetch_problems_all.py
@@ -1,6 +1,7 @@
 import urllib3
 import json
 import time
+import random
 import os
 from dotenv import dotenv_values
 
@@ -102,7 +103,7 @@ def fetch_all_problems(cf_clearance, csrftoken):
         all_questions.extend(questions)
         print('Fetched page %d: %d/%d problems' % (skip // PAGE_SIZE + 1, len(all_questions), total_count))
         skip += PAGE_SIZE
-        time.sleep(0.5)
+        time.sleep(0.5 + random.random())
 
     return all_questions
 

--- a/fetch_problems_all.py
+++ b/fetch_problems_all.py
@@ -14,7 +14,10 @@ config = {
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
-def fetch_problems(cf_clearance, csrftoken, limit=50):
+PAGE_SIZE = 100
+
+
+def fetch_problems_page(cf_clearance, csrftoken, limit=PAGE_SIZE, skip=0):
     http = urllib3.PoolManager(cert_reqs='CERT_NONE')
     cookie = 'cf_clearance=%s; csrftoken=%s' % (cf_clearance, csrftoken)
     data = {
@@ -56,7 +59,7 @@ def fetch_problems(cf_clearance, csrftoken, limit=50):
         ''',
         'variables': {
             'categorySlug': '',
-            'skip': 0,
+            'skip': skip,
             'limit': limit,
             'filters': {},
         },
@@ -86,6 +89,24 @@ def fetch_problems(cf_clearance, csrftoken, limit=50):
     return response_content
 
 
+def fetch_all_problems(cf_clearance, csrftoken):
+    first_page = fetch_problems_page(cf_clearance, csrftoken, limit=PAGE_SIZE, skip=0)
+    total_count = first_page['data']['problemsetQuestionList']['total']
+    all_questions = list(first_page['data']['problemsetQuestionList']['questions'])
+    print('Fetched page 1: %d/%d problems' % (len(all_questions), total_count))
+
+    skip = PAGE_SIZE
+    while skip < total_count:
+        page = fetch_problems_page(cf_clearance, csrftoken, limit=PAGE_SIZE, skip=skip)
+        questions = page['data']['problemsetQuestionList']['questions']
+        all_questions.extend(questions)
+        print('Fetched page %d: %d/%d problems' % (skip // PAGE_SIZE + 1, len(all_questions), total_count))
+        skip += PAGE_SIZE
+        time.sleep(0.5)
+
+    return all_questions
+
+
 def main():
     print('Now load cf_clearance and csrftoken...')
     cf_clearance = config.get("LC_CF_CLEARANCE", None)
@@ -94,15 +115,10 @@ def main():
         raise RuntimeError('Fail to load cf_clearance and csrftoken from environ!')
     print('Got cf_clearance %s and csrftoken %s.' % (cf_clearance, csrftoken))
 
-    print('Now try get LeetCode problems total count...')
-    response_content = fetch_problems(cf_clearance, csrftoken)
-    total_count = response_content['data']['problemsetQuestionList']['total']
-    print('Found %d problems in total.' % total_count)
+    print('Now fetching all LeetCode problems (paginated, %d per page)...' % PAGE_SIZE)
+    all_questions = fetch_all_problems(cf_clearance, csrftoken)
 
-    print('Now try fetch all %d LeetCode problems...' % total_count)
-    response_content = fetch_problems(cf_clearance, csrftoken, total_count)
-    questions_all = {q['frontendQuestionId']: q for q in
-                     response_content['data']['problemsetQuestionList']['questions']}
+    questions_all = {q['frontendQuestionId']: q for q in all_questions}
     for question_id in questions_all.keys():
         question_stats_json = questions_all[question_id]['stats']
         totalAcceptedRaw = totalSubmissionRaw = None
@@ -115,11 +131,11 @@ def main():
         questions_all[question_id]['totalAcceptedRaw'] = totalAcceptedRaw
         questions_all[question_id]['totalSubmissionRaw'] = totalSubmissionRaw
         del questions_all[question_id]['stats']
-    print('All %d problems fetched.' % total_count)
+    print('All %d problems fetched.' % len(questions_all))
 
     with open('problems_all.json', 'w') as f:
         f.write(json.dumps(questions_all))
-        print('All %d problems info saved into problems_all.json file.' % total_count)
+        print('All %d problems info saved into problems_all.json file.' % len(questions_all))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Context

Reported in this issue: https://github.com/bunnyxt/lcid/issues/8, since commit https://github.com/bunnyxt/lcid/commit/626c49b62e5a113f9e0dd16760abf3e7c03b4240, only first 100 questions are collected in problems_all.json

## Summary

- LeetCode's GraphQL API now enforces a max `limit` of 100 per request, breaking the previous approach of fetching all problems in a single call.
- Refactored `fetch_problems_all.py` to paginate through problems in batches of 100 with randomized delay (0.5–1.5s) between requests.
- Investigated the new `problemsetQuestionListV2` API as a potential migration target. Key findings:
  - V2 returns data in a slightly different format (`difficulty` is uppercase, `acRate` is a decimal instead of percentage).
  - V2 does **not** support several fields we rely on: `stats` (totalAcceptedRaw/totalSubmissionRaw), `likes`, `dislikes`, `hasSolution`, `hasVideoSolution`, `categoryTitle`.
  - Decision: stay on V1 with pagination for now to preserve all existing fields.

## Test plan

- [x] Verified V1 pagination fetches all 3859 problems correctly
- [ ] Confirm `problems_all.json` output matches expected schema downstream