### PR TITLE
Normalize JSON responses and China site redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This simple project, called LCid, provides directly access to LeetCode problems 
 
 - Fetch all LeetCode problems via crawler.
 - Redirect to LeetCode problem page with problem id in the URL path via backend.
-- Support both LeetCode [global site](https://leetcode.com/problemset/all/) and [China site](https://leetcode-cn.com/problemset/all/) redirect.
+- Support both LeetCode [global site](https://leetcode.com/problemset/all/) and [China site](https://leetcode.cn/problemset/all/) redirect.
 - CI/CD, fetch all LeetCode problems daily and commit back to repository via GitHub Actions, then trigger backend rebuild and redeploy with the latest problems via Heroku.
 
 ![redirect-demo](redirect-demo.gif)

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 import sys
-from flask import Flask, redirect
+from flask import Flask, jsonify, redirect
 from flask_cors import CORS
 from waitress import serve
 import json
@@ -55,21 +55,24 @@ def go_redirect(problem_id):
 def go_redirect_cn(problem_id):
     problem_info = problems_all.get(problem_id, None)
     if not problem_info:
-        return 'Fail to redirect to leetcode-cn problem %s page.' % problem_id
-    return redirect('https://leetcode-cn.com/problems/%s/' % problem_info['titleSlug'])
+        return 'Fail to redirect to leetcode.cn problem %s page.' % problem_id, 404
+    return redirect('https://leetcode.cn/problems/%s/' % problem_info['titleSlug'])
 
 
 @app.route('/info')
 def info_all():
-    return json.dumps(problems_all)
+    return jsonify(problems_all)
 
 
 @app.route('/info/<problem_id>')
 def info(problem_id):
     problem_info = problems_all.get(problem_id, None)
     if not problem_info:
-        return '{"code":404,"message":"Fail to get info of leetcode problem %s."}' % problem_id, 404
-    return json.dumps(problems_all[problem_id])
+        return jsonify(
+            code=404,
+            message='Fail to get info of leetcode problem %s.' % problem_id,
+        ), 404
+    return jsonify(problem_info)
 
 
 if __name__ == "__main__":

--- a/src/components/ProblemsTable.jsx
+++ b/src/components/ProblemsTable.jsx
@@ -313,7 +313,7 @@ const ProblemsTable = () => {
             return (
               <span className="title">
                 <a 
-                  href={`https://www.leetcode.${redirectSite}/problems/${titleSlug}`} 
+                  href={`https://leetcode.${redirectSite}/problems/${titleSlug}`}
                   target="_blank" 
                   rel="noreferrer"
                   title={`go to problem page of ${titleSlug}`}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,51 @@
+import unittest
+
+from app import app, problems_all
+
+
+class AppRoutesTestCase(unittest.TestCase):
+    def setUp(self):
+        app.config.update(TESTING=True)
+        self.client = app.test_client()
+
+    def test_info_all_returns_json(self):
+        response = self.client.get('/info')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, 'application/json')
+        self.assertIn('1', response.get_json())
+
+    def test_info_returns_problem_json(self):
+        response = self.client.get('/info/1')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, 'application/json')
+        self.assertEqual(response.get_json(), problems_all['1'])
+
+    def test_info_returns_json_404_for_unknown_problem(self):
+        response = self.client.get('/info/999999')
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.mimetype, 'application/json')
+        self.assertEqual(response.get_json(), {
+            'code': 404,
+            'message': 'Fail to get info of leetcode problem 999999.',
+        })
+
+    def test_china_redirect_uses_current_domain(self):
+        response = self.client.get('/cn/1')
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.headers['Location'],
+            'https://leetcode.cn/problems/two-sum/',
+        )
+
+    def test_china_redirect_returns_404_for_unknown_problem(self):
+        response = self.client.get('/cn/999999')
+
+        self.assertEqual(response.status_code, 404)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- return Flask JSON responses from the problem information endpoints
- redirect China-site requests and frontend links directly to `leetcode.cn`
- return HTTP 404 for unknown China-site problem IDs
- add Flask route regression tests and update the README link

## Verification

- `.venv/bin/python -m unittest discover -s tests -v`
- `npm run build`
- browser check: switching to China site produces `https://leetcode.cn/problems/two-sum`