### PR TITLE
fix: antd v6 visual regressions from the Vite migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build/
 venv/
 .venv/
 .env.local
+
+# Claude Code local settings
+.claude/

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,18 +1,21 @@
 import React from 'react';
+import { App as AntApp } from 'antd';
 import './App.css';
 import RedirectCard from './components/RedirectCard';
 import ProblemsTable from './components/ProblemsTable';
 
 const App = () => {
   return (
-    <div className="App">
-      <div className="redirect-wrapper">
-        <RedirectCard />
+    <AntApp>
+      <div className="App">
+        <div className="redirect-wrapper">
+          <RedirectCard />
+        </div>
+        <div className="problems-table-wrapper">
+          <ProblemsTable />
+        </div>
       </div>
-      <div className="problems-table-wrapper">
-        <ProblemsTable />
-      </div>
-    </div>
+    </AntApp>
   );
 };
 

--- a/src/components/ProblemsTable.css
+++ b/src/components/ProblemsTable.css
@@ -64,11 +64,15 @@
 }
 
 .topics-container {
-  margin-bottom: -4px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 8px;
 }
 
 .topic-tag {
-  margin-bottom: 4px;
+  /* antd v6 Tag no longer ships a default trailing margin; the container gap
+     handles spacing instead. */
+  margin: 0;
   cursor: pointer;
 }
 

--- a/src/components/ProblemsTable.jsx
+++ b/src/components/ProblemsTable.jsx
@@ -326,7 +326,7 @@ const ProblemsTable = () => {
         <Table.Column 
           title="Like Rate" 
           key="likeRate" 
-          width={108}
+          width={120}
           sorter={(a, b) => b.likeRate - a.likeRate}
           render={(problem) => {
             const { likes, dislikes, likeRate } = problem;
@@ -356,7 +356,7 @@ const ProblemsTable = () => {
         <Table.Column 
           title="AC Rate" 
           key="acRate" 
-          width={108}
+          width={120}
           sorter={(a, b) => b.acRate - a.acRate}
           render={(problem) => {
             const { acRate, totalSubmissionRaw, totalAcceptedRaw } = problem;
@@ -386,7 +386,7 @@ const ProblemsTable = () => {
         <Table.Column 
           title="Difficulty" 
           key="difficulty" 
-          width={108}
+          width={120}
           filters={[
             { text: 'Easy', value: 'Easy'}, 
             { text: 'Medium', value: 'Medium'}, 

--- a/src/components/ProblemsTable.jsx
+++ b/src/components/ProblemsTable.jsx
@@ -245,7 +245,7 @@ const ProblemsTable = () => {
           filterIcon={(filtered) => (
             <SearchOutlined
               style={{
-                color: filtered ? '#1890ff' : undefined,
+                color: filtered ? '#1677ff' : undefined,
               }}
             />
           )}
@@ -298,7 +298,7 @@ const ProblemsTable = () => {
           filterIcon={(filtered) => (
             <SearchOutlined
               style={{
-                color: filtered ? '#1890ff' : undefined,
+                color: filtered ? '#1677ff' : undefined,
               }}
             />
           )}

--- a/src/components/RedirectCard.css
+++ b/src/components/RedirectCard.css
@@ -29,7 +29,7 @@
 }
 
 .redirect-id-input-suffix span:hover {
-  color: #1890ff;
+  color: #1677ff;
 }
 
 .redirect-link-grid {

--- a/src/components/RedirectLink.css
+++ b/src/components/RedirectLink.css
@@ -4,7 +4,7 @@
 }
 
 .redirect-link-suffix span:hover {
-  color: #1890ff;
+  color: #1677ff;
 }
 
 .premium-tag {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import 'antd/dist/reset.css';
 import './index.css';
 import App from './App';
 


### PR DESCRIPTION
Follow-up to #17. Fixes visual regressions introduced by the antd v4 → v6 upgrade in that PR.

## Changes

- **Global CSS reset.** The migration dropped the `antd/dist/antd.css` import, but antd v6 is CSS-in-JS and ships no global reset by default. Import `antd/dist/reset.css` so `box-sizing: border-box`, heading, and form-element normalization are restored. Without it the custom layout CSS (written assuming border-box) overflowed its containers and the bare headings fell back to browser defaults.
- **Link styling.** Wrap the app in antd's `App` component so bare anchors (e.g. the footer links) pick up antd's link styling the same way anchors rendered inside antd components already do.
- **Primary color.** Replace the hard-coded antd v4 primary blue (`#1890ff`) with the v6 value (`#1677ff`) in the remaining inline styles and hover rules.
- **Topics tag spacing.** antd v6 `Tag` no longer ships a default trailing margin, so the Topics cell tags rendered with no gap. Lay them out with flex + gap instead.
- **Column widths.** Bump the Like Rate, AC Rate, and Difficulty columns from 108 to 120 so their headers no longer wrap to two lines.

## Verification

- `npm run build` — clean
- `python -m unittest discover -s tests` — 5 passed
- Browser check at desktop and narrow widths: redirect card layout, problems table, Topics tag spacing, column headers, footer/title link styling; no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)