### PR TITLE
feat: light/dark theme support

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,23 @@
     <link rel="apple-touch-icon" href="/lcid_logo_192.png" />
     <link rel="manifest" href="/manifest.json" />
     <title>LCid - access LeetCode problems via id</title>
+    <script>
+      // Set the theme before first paint to avoid a flash of the wrong mode.
+      (function () {
+        try {
+          var saved = localStorage.getItem('lcid-theme');
+          var dark = saved
+            ? saved === 'dark'
+            : window.matchMedia('(prefers-color-scheme: dark)').matches;
+          var root = document.documentElement;
+          root.dataset.theme = dark ? 'dark' : 'light';
+          root.style.colorScheme = dark ? 'dark' : 'light';
+          root.style.backgroundColor = dark ? '#141414' : '#ffffff';
+        } catch (e) {
+          /* localStorage/matchMedia unavailable: fall back to light */
+        }
+      })();
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,5 @@
 code {
-  background-color: #f0f0f0;
+  background-color: var(--app-code-bg);
   padding: 0 4px;
   border-radius: 4px;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,12 +2,14 @@ import React, { lazy, Suspense } from 'react';
 import { App as AntApp, Spin } from 'antd';
 import './App.css';
 import RedirectCard from './components/RedirectCard';
+import ThemeToggle from './theme/ThemeToggle';
 
 const ProblemsTable = lazy(() => import('./components/ProblemsTable'));
 
 const App = () => {
   return (
     <AntApp>
+      <ThemeToggle />
       <div className="App">
         <div className="redirect-wrapper">
           <RedirectCard />

--- a/src/components/ColorIndicator.jsx
+++ b/src/components/ColorIndicator.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { theme } from 'antd';
 
 const ColorIndicator = ({
   position,
 }) => {
+  const { token } = theme.useToken();
   const height = 2;
   const lineX = `${position * 100}%`;
   return (
@@ -15,7 +17,7 @@ const ColorIndicator = ({
         y1="0"
         x2={lineX}
         y2={height}
-        stroke="#000000d9"
+        stroke={token.colorText}
         strokeWidth="2"
       />
     </svg>

--- a/src/components/ProblemsTable.css
+++ b/src/components/ProblemsTable.css
@@ -77,7 +77,7 @@
 }
 
 .topics-hidden {
-  color: #bfbfbf;
+  color: var(--app-topics-hidden);
 }
 
 .popularity-tooltip {

--- a/src/components/ProblemsTable.jsx
+++ b/src/components/ProblemsTable.jsx
@@ -1,11 +1,13 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { SearchOutlined, SettingOutlined } from '@ant-design/icons';
-import { Table, Tag, Tooltip, Input, Row, Col, Button, Popover } from 'antd';
+import { Table, Tag, Tooltip, Input, Row, Col, Button, Popover, theme } from 'antd';
 import ProblemsTableControl from './ProblemsTableControl';
 import ColorIndicator from './ColorIndicator';
 import './ProblemsTable.css';
 
 const ProblemsTable = () => {
+  const { token } = theme.useToken();
+
   const [loadingProblems, setLoadingProblems] = useState(false);
   const [problems, setProblems] = useState([]);
   const [topics, setTopics] = useState([]);
@@ -250,7 +252,7 @@ const ProblemsTable = () => {
           filterIcon={(filtered) => (
             <SearchOutlined
               style={{
-                color: filtered ? '#1677ff' : undefined,
+                color: filtered ? token.colorPrimary : undefined,
               }}
             />
           )}
@@ -303,7 +305,7 @@ const ProblemsTable = () => {
           filterIcon={(filtered) => (
             <SearchOutlined
               style={{
-                color: filtered ? '#1677ff' : undefined,
+                color: filtered ? token.colorPrimary : undefined,
               }}
             />
           )}

--- a/src/components/RedirectCard.css
+++ b/src/components/RedirectCard.css
@@ -1,5 +1,5 @@
 .color-l {
-  color: rgb(0, 0, 0);
+  color: var(--app-title-strong);
 }
 
 .color-c {
@@ -7,7 +7,7 @@
 }
 
 .color-id {
-  color: rgb(179, 179, 179);
+  color: var(--app-title-muted);
 }
 
 .redirect-card {
@@ -16,7 +16,8 @@
   padding: 4rem;
   border-radius: 1rem;
   text-align: center;
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+  background-color: var(--app-card-bg);
+  box-shadow: var(--app-card-shadow);
 }
 
 .redirect-id-input {
@@ -29,7 +30,7 @@
 }
 
 .redirect-id-input-suffix span:hover {
-  color: #1677ff;
+  color: var(--app-link);
 }
 
 .redirect-link-grid {

--- a/src/components/RedirectLink.css
+++ b/src/components/RedirectLink.css
@@ -4,7 +4,7 @@
 }
 
 .redirect-link-suffix span:hover {
-  color: #1677ff;
+  color: var(--app-link);
 }
 
 .premium-tag {

--- a/src/index.css
+++ b/src/index.css
@@ -36,6 +36,10 @@ html[data-theme='dark'] {
   --app-icon-hover: #ffffff;
 }
 
+html {
+  background-color: var(--app-bg);
+}
+
 body {
   margin: 0;
   background-color: var(--app-bg);

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,44 @@
+/*
+ * Theme tokens for the app's own (non-antd) styling. antd components follow
+ * ConfigProvider's algorithm; these cover the hand-written colors that don't.
+ * The `data-theme` attribute is set on <html> before first paint (see
+ * index.html) and kept in sync by ThemeProvider.
+ */
+:root {
+  --app-bg: #ffffff;
+  --app-title-strong: #000000;
+  --app-title-muted: rgb(179, 179, 179);
+  --app-code-bg: #f0f0f0;
+  --app-card-bg: transparent;
+  --app-card-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2),
+    0 6px 20px 0 rgba(0, 0, 0, 0.19);
+  --app-topics-hidden: #bfbfbf;
+  --app-link: #1677ff;
+  --app-border: rgba(0, 0, 0, 0.15);
+  --app-toggle-bg: #ffffff;
+  --app-icon: #8c8c8c;
+  --app-icon-hover: #000000;
+}
+
+html[data-theme='dark'] {
+  --app-bg: #141414;
+  --app-title-strong: #ffffff;
+  --app-title-muted: #8c8c8c;
+  --app-code-bg: #2a2a2a;
+  --app-card-bg: #1f1f1f;
+  --app-card-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.45),
+    0 6px 20px 0 rgba(0, 0, 0, 0.4);
+  --app-topics-hidden: #595959;
+  --app-link: #3c89e8;
+  --app-border: rgba(255, 255, 255, 0.2);
+  --app-toggle-bg: #1f1f1f;
+  --app-icon: #8c8c8c;
+  --app-icon-hover: #ffffff;
+}
+
 body {
   margin: 0;
+  background-color: var(--app-bg);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,8 +3,11 @@ import ReactDOM from 'react-dom/client';
 import 'antd/dist/reset.css';
 import './index.css';
 import App from './App';
+import ThemeProvider from './theme/ThemeProvider';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <App />
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>
 );

--- a/src/theme/ThemeProvider.jsx
+++ b/src/theme/ThemeProvider.jsx
@@ -36,6 +36,10 @@ const ThemeSync = ({ dark }) => {
     const root = document.documentElement;
     root.dataset.theme = dark ? 'dark' : 'light';
     root.style.colorScheme = dark ? 'dark' : 'light';
+    // The bootstrap script in index.html sets an inline background-color to
+    // avoid a flash before CSS loads. Drop it now so the themed CSS variable
+    // (which tracks data-theme) takes over on every toggle.
+    root.style.removeProperty('background-color');
   }, [dark]);
   return null;
 };

--- a/src/theme/ThemeProvider.jsx
+++ b/src/theme/ThemeProvider.jsx
@@ -1,0 +1,74 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { ConfigProvider, theme as antdTheme } from 'antd';
+
+const STORAGE_KEY = 'lcid-theme';
+
+const ThemeContext = createContext({ dark: false, toggle: () => {} });
+
+export const useTheme = () => useContext(ThemeContext);
+
+const getInitialDark = () => {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved === 'dark') return true;
+    if (saved === 'light') return false;
+  } catch (e) {
+    /* localStorage unavailable */
+  }
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  );
+};
+
+// Keeps the <html> element in sync with the active theme so the CSS custom
+// properties (and the browser's form controls / scrollbars) follow it.
+const ThemeSync = ({ dark }) => {
+  useEffect(() => {
+    const root = document.documentElement;
+    root.dataset.theme = dark ? 'dark' : 'light';
+    root.style.colorScheme = dark ? 'dark' : 'light';
+  }, [dark]);
+  return null;
+};
+
+const ThemeProvider = ({ children }) => {
+  const [dark, setDark] = useState(getInitialDark);
+
+  const toggle = useCallback(() => {
+    setDark((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(STORAGE_KEY, next ? 'dark' : 'light');
+      } catch (e) {
+        /* localStorage unavailable */
+      }
+      return next;
+    });
+  }, []);
+
+  const value = useMemo(() => ({ dark, toggle }), [dark, toggle]);
+
+  return (
+    <ConfigProvider
+      theme={{
+        algorithm: dark ? antdTheme.darkAlgorithm : antdTheme.defaultAlgorithm,
+      }}
+    >
+      <ThemeContext.Provider value={value}>
+        <ThemeSync dark={dark} />
+        {children}
+      </ThemeContext.Provider>
+    </ConfigProvider>
+  );
+};
+
+export default ThemeProvider;

--- a/src/theme/ThemeToggle.css
+++ b/src/theme/ThemeToggle.css
@@ -1,0 +1,30 @@
+.theme-toggle {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 100;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid var(--app-border);
+  border-radius: 50%;
+  background-color: var(--app-toggle-bg);
+  color: var(--app-icon);
+  cursor: pointer;
+  transition: color 0.3s, border-color 0.3s, background-color 0.3s;
+}
+
+.theme-toggle:hover {
+  color: var(--app-icon-hover);
+  border-color: var(--app-icon-hover);
+}
+
+@media screen and (max-width: 767px) {
+  .theme-toggle {
+    top: 0.75rem;
+    right: 0.75rem;
+  }
+}

--- a/src/theme/ThemeToggle.jsx
+++ b/src/theme/ThemeToggle.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { useTheme } from './ThemeProvider';
+import './ThemeToggle.css';
+
+const SunIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <circle cx="12" cy="12" r="4.5" fill="currentColor" />
+    <g stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <line x1="12" y1="1.5" x2="12" y2="4" />
+      <line x1="12" y1="20" x2="12" y2="22.5" />
+      <line x1="1.5" y1="12" x2="4" y2="12" />
+      <line x1="20" y1="12" x2="22.5" y2="12" />
+      <line x1="4.2" y1="4.2" x2="6" y2="6" />
+      <line x1="18" y1="18" x2="19.8" y2="19.8" />
+      <line x1="19.8" y1="4.2" x2="18" y2="6" />
+      <line x1="6" y1="18" x2="4.2" y2="19.8" />
+    </g>
+  </svg>
+);
+
+const MoonIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path
+      d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+const ThemeToggle = () => {
+  const { dark, toggle } = useTheme();
+  const label = dark ? 'Switch to light mode' : 'Switch to dark mode';
+  return (
+    <button
+      type="button"
+      className="theme-toggle"
+      onClick={toggle}
+      aria-label={label}
+      title={label}
+    >
+      {dark ? <SunIcon /> : <MoonIcon />}
+    </button>
+  );
+};
+
+export default ThemeToggle;


### PR DESCRIPTION
Adds a light/dark mode toggle. Builds on antd v6's `darkAlgorithm`; the work not covered by antd is the theme state, the toggle, and the hand-written colors.

## How it works

- **`ThemeProvider`** holds the `dark` state — initialised from `localStorage` (`lcid-theme`), falling back to `prefers-color-scheme` on a first visit — and feeds `theme.darkAlgorithm` / `theme.defaultAlgorithm` into `ConfigProvider`, so every antd component follows.
- **`ThemeToggle`** — a fixed top-right sun/moon button.
- **Inline script in `index.html`** sets `data-theme` on `<html>` before first paint, so a reload in dark mode doesn't flash light.
- **Hand-written colors** antd's algorithm can't reach — the `LCid` title, card background + shadow, `code` background, the `ColorIndicator` position line, the hidden-topics placeholder, the icon hover colors — now come from CSS custom properties keyed off `data-theme`, or from `theme.useToken()` where they're set inline (`ColorIndicator`, the table filter icon).

## Verification

- `npm run build` — no chunk-size warning
- `python -m unittest discover -s tests` — 5 passed
- Browser: toggle switches both modes; light mode is visually unchanged; dark mode covers the redirect card, inputs, table, tags, filter dropdowns, pagination, links, and the rate mini-bars; Id and Title filters work in dark; preference persists across reloads with no flash; clearing the stored preference falls back to the OS setting; no console errors

## Note

The initial JS chunk is now 499 kB — just under Vite's 500 kB warning threshold (both `defaultAlgorithm` and `darkAlgorithm` are bundled). A future addition could tip it over and reintroduce the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)